### PR TITLE
build_image.sh: do not truncate the image. If should be fixed size 1MB

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -101,7 +101,7 @@ _output_file(){
         fi
         if _file_exists $app_b_bin
         then
-            dd if=$app_b_bin of="$OUT_BIN" bs=1 count=$APP_B_SIZE seek=$APP_B_OFFSET
+            dd if=$app_b_bin of="$OUT_BIN" bs=1 count=$APP_B_SIZE seek=$APP_B_OFFSET conv=notrunc
         else
             echo "Please check if there is a problem with the compiler."
             echo "Aborting..."


### PR DESCRIPTION
According to [Secure Boot](https://github.com/VitroTech/shared-docs/blob/main/shard-v2-secure-boot.md#firmware-changes) document, the image should be 1MB  fixed size.

Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>