### PR TITLE
info on minimal printf with mbedOS 6.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,25 @@ To build template application run docker_build_image.sh:
 Now the application is ready to be flashed on the Vitro Shard. The compiled
 application binary is named `image.bin` and can be found in the `bin/` folder.
 It can be done by using `docker_flash_image.sh` script.
+
+# Notes on mbedOS 6.x
+To reduce the code size Mbed introduced Minimal printf and snprintf. As of Mbed OS 6.0 it is enabled by default. Floating point parameters are only present when minimal-printf-enable-floating-point config is set to true (disabled by default) as shown below:
+```
+"target_overrides": {
+        "*": {
+            "target.printf_lib": "minimal-printf",
+            "platform.minimal-printf-enable-floating-point": true,
+            "platform.minimal-printf-set-floating-point-max-decimals": 6,
+            "platform.minimal-printf-enable-64-bit": false
+        }
+    }
+```
+
+If your application requires more advanced functionality (at the cost of using more flash memory) you can switch to the standard printf library configuring it in mbed_app.json file by overriding the parameter target.printf_lib with the value std as shown below:
+ ```
+ "target_overrides": {
+        "*": {
+            "target.printf_lib": "std"
+        }
+    }
+```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ application binary is named `image.bin` and can be found in the `bin/` folder.
 It can be done by using `docker_flash_image.sh` script.
 
 # Notes on mbedOS 6.x
-To reduce the code size Mbed introduced Minimal printf and snprintf. As of Mbed OS 6.0 it is enabled by default. Floating point parameters are only present when minimal-printf-enable-floating-point config is set to true (disabled by default) as shown below:
+To reduce the code size Mbed introduced Minimal printf and snprintf. As of 
+Mbed OS 6.0 it is enabled by default. Floating point parameters are only 
+present when minimal-printf-enable-floating-point config is set to true 
+(disabled by default) as shown below:
 ```
 "target_overrides": {
         "*": {
@@ -48,7 +51,10 @@ To reduce the code size Mbed introduced Minimal printf and snprintf. As of Mbed 
     }
 ```
 
-If your application requires more advanced functionality (at the cost of using more flash memory) you can switch to the standard printf library configuring it in mbed_app.json file by overriding the parameter target.printf_lib with the value std as shown below:
+If your application requires more advanced functionality (at the cost of 
+using more flash memory) you can switch to the standard printf library 
+configuring it in mbed_app.json file by overriding the parameter 
+target.printf_lib with the value std as shown below:
  ```
  "target_overrides": {
         "*": {


### PR DESCRIPTION
Most applications use extensively float on printf and then it is necessary to be aware of the default status coming with mbedOS 6.x