### PR TITLE
make use of the new frame type

### DIFF
--- a/Applications/IoTBlock-test/main.cpp
+++ b/Applications/IoTBlock-test/main.cpp
@@ -74,11 +74,8 @@ void handler(const CanbusFrame& frame){
         frame.parameterId(),
         frame.dataLength()
     )
+    /* print contents of the frame on serial port */
     for(int i = 0; i < frame.dataLength(); i++){
-        /* 
-         * NOTE: printf might not be the best functions, it works,
-         * but very poorly
-         */
         printf("%x ", frame.data()[i]);
     }
     printf("\n");

--- a/Applications/IoTBlock-test/main.cpp
+++ b/Applications/IoTBlock-test/main.cpp
@@ -12,6 +12,25 @@ using namespace vitroio::sdk;
 
 #define SERIAL_BAUDRATE 115200
 
+#define CAN_HANDLER_INFO(format, ...) VITROIO_DEBUG_INFO("CAN HANDLER", format, ##__VA_ARGS__);
+
+void handler(const CanbusFrame& frame){
+    CAN_HANDLER_INFO(
+        "Got frame id: %x, param id: %x, data size: %d",
+        frame.nodeId(),
+        frame.parameterId(),
+        frame.dataLength()
+    )
+    for(int i = 0; i < frame.dataLength(); i++){
+        /* 
+         * NOTE: printf might not be the best functions, it works,
+         * but very poorly
+         */
+        printf("%x ", frame.data()[i]);
+    }
+    printf("\n ");
+}
+
 /**
  * Watchdog ticker
  */
@@ -91,6 +110,8 @@ int main()
     if(err != VITROIO_ERR_SUCCESS){
         MAIN_ERROR("Failed to initialize communication");
     }
+
+    node.setExternalFrameCallback(&handler);
 
     IoTBlock iotBlock = IoTBlock(&can_layer);
     uint8_t block[256] = {0};

--- a/Applications/IoTBlock-test/main.cpp
+++ b/Applications/IoTBlock-test/main.cpp
@@ -14,23 +14,6 @@ using namespace vitroio::sdk;
 
 #define CAN_HANDLER_INFO(format, ...) VITROIO_DEBUG_INFO("CAN HANDLER", format, ##__VA_ARGS__);
 
-void handler(const CanbusFrame& frame){
-    CAN_HANDLER_INFO(
-        "Got frame id: %x, param id: %x, data size: %d",
-        frame.nodeId(),
-        frame.parameterId(),
-        frame.dataLength()
-    )
-    for(int i = 0; i < frame.dataLength(); i++){
-        /* 
-         * NOTE: printf might not be the best functions, it works,
-         * but very poorly
-         */
-        printf("%x ", frame.data()[i]);
-    }
-    printf("\n ");
-}
-
 /**
  * Watchdog ticker
  */
@@ -83,6 +66,24 @@ FileHandle *mbed::mbed_override_console(int fd)
 void kickWatchdog(){
 	Watchdog::get_instance().kick();
 }
+
+void handler(const CanbusFrame& frame){
+    CAN_HANDLER_INFO(
+        "Got frame id: %x, param id: %x, data size: %d",
+        frame.nodeId(),
+        frame.parameterId(),
+        frame.dataLength()
+    )
+    for(int i = 0; i < frame.dataLength(); i++){
+        /* 
+         * NOTE: printf might not be the best functions, it works,
+         * but very poorly
+         */
+        printf("%x ", frame.data()[i]);
+    }
+    printf("\n");
+}
+
 
 int main()
 {

--- a/Applications/IoTBlock-test/main.cpp
+++ b/Applications/IoTBlock-test/main.cpp
@@ -104,8 +104,7 @@ int main()
         MAIN_ERROR("Failed to configure Shard Edge");
     }
 
-    int err = node.initCommunication(&can_layer);
-    if(err != VITROIO_ERR_SUCCESS){
+    while(node.initCommunication(&can_layer) != VITROIO_ERR_SUCCESS){
         MAIN_ERROR("Failed to initialize communication");
     }
 


### PR DESCRIPTION
I added a new frame type `0x60`, on callback if paramID is `0x60`, then node ID is checked and if a callback was set. If it all was set, the user defined handler is called with the received frame.

A use example:

// define an info print
#define CAN_HANDLER_INFO(format, ...) VITROIO_DEBUG_INFO("CAN HANDLER", format, ##__VA_ARGS__);

```
...

// Define a simple handler that will print all frame info onto the serial bus
void handler(const CanbusFrame& frame){
    CAN_HANDLER_INFO(
        "Got frame id: %x, param id: %x, data size: %d",
        frame.nodeId(),
        frame.parameterId(),
        frame.dataLength()
    )
    /* print contents of the frame on serial port */
    for(int i = 0; i < frame.dataLength(); i++){
        printf("%x ", frame.data()[i]);
    }
    printf("\n");
}

...

int main()
{
// attach the handler on application setup
    node.setExternalFrameCallback(&handler);

}
```

Then on crystal we can for example use cansend

```
cansend can0 00000860#1234abcd
```

Which results with:

```
[INFO][CAN HANDLER]: Got frame id: 1, param id: 60, data size: 4
12 34 ab cd
```

on shard's serial bus.